### PR TITLE
fix: removed dotenv which was interferring with routing in react native

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,83 @@
-# Welcome to your Expo app 👋
+# Catawaracle 🐱
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+Welcome to Catawaracle, an Expo-based application.
 
-## Get started
+This project allows users to browse, vote, favorite, and upload cat images.
 
-1. Install dependencies
+## Table of Contents
+
+- [Project Overview](#project-overview)
+- [Installation](#installation)
+- [Running the Project](#running-the-project)
+- [Tests](#tests)
+
+## Project Overview
+
+Catawaracle is an application built with Expo that enables users to interact with cat images. Users can browse through images, vote on their favorites, add images to their favorites list, and upload new images.
+
+## Installation
+
+To get started with the project, follow these steps:
+
+### Prerequisites
+
+Before starting please make sure you have setup the appropriate software on your local environment:
+
+- Node
+  ```sh
+  nvm install latest
+  node -v
+  ```
+- Yarn
+  ```sh
+  brew install yarn
+  ```
+
+1. Clone the repository:
 
    ```bash
-   npm install
+   git clone https://github.com/wsarkhan/catawaracle.git
+   cd catawaracle
+
    ```
 
-2. Start the app
+2. Install dependencies:
 
    ```bash
-    npx expo start
+   yarn install
+
    ```
 
-In the output, you'll find options to open the app in a
+3. Create a .env file in the root folder with the cat API key:
+   ```bash
+   EXPO_PUBLIC_CAT_API_KEY=your_secret_key
+   ```
+
+## Running the Project
+
+To start the application, use the following command:
+
+```
+yarn start
+```
+
+In the output, you'll find options to open the app in a:
+
+development build
 
 - [development build](https://docs.expo.dev/develop/development-builds/introduction/)
 - [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
 - [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
 - [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
 
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
+## Tests
 
-## Get a fresh project
+### Unit tests
 
-When you're ready, run:
+Assuming you can run the builds, no pre-requisites should be needed for the unit tests.
 
-```bash
-npm run reset-project
+To run:
+
 ```
-
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
-
-## Learn more
-
-To learn more about developing your project with Expo, look at the following resources:
-
-- [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
-- [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
-
-## Join the community
-
-Join our community of developers creating universal apps.
-
-- [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+yarn test
+```

--- a/api/api.ts
+++ b/api/api.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
-import { CAT_API_KEY } from '@env';
 import { CatImage } from '@/types';
+
+const secret_key = process.env.EXPO_PUBLIC_CAT_API_KEY;
 
 const apiClient = axios.create({
   baseURL: 'https://api.thecatapi.com/v1',
-  headers: { 'x-api-key': CAT_API_KEY },
+  headers: { 'x-api-key': secret_key },
 });
 
 export const fetchCatImages = async (limit = 10): Promise<CatImage[]> => {
@@ -60,7 +61,7 @@ export const uploadImage = async (imageUri: string): Promise<CatImage> => {
     formData,
     {
       headers: {
-        'x-api-key': CAT_API_KEY,
+        'x-api-key': secret_key,
         'Content-Type': 'multipart/form-data',
       },
     },

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,5 @@ module.exports = function (api) {
       ['babel-preset-expo', { jsxImportSource: 'nativewind' }],
       'nativewind/babel',
     ],
-    plugins: [['module:react-native-dotenv']],
   };
 };

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,3 +1,0 @@
-declare module '@env' {
-  export const CAT_API_KEY: string;
-}

--- a/hooks/useFavourites/useFavourites.ts
+++ b/hooks/useFavourites/useFavourites.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import axios from 'axios';
-import { CAT_API_KEY } from '@env';
+
+const secret_key = process.env.EXPO_PUBLIC_CAT_API_KEY;
 
 export const useFavorites = (
   showCustomAlert: (title: string, message: string) => void,
@@ -13,7 +14,7 @@ export const useFavorites = (
       const response = await axios.get(
         'https://api.thecatapi.com/v1/favourites',
         {
-          headers: { 'x-api-key': CAT_API_KEY },
+          headers: { 'x-api-key': secret_key },
         },
       );
       const updatedFavorites = response.data.reduce(
@@ -40,7 +41,7 @@ export const useFavorites = (
         if (favoriteId) {
           await axios.delete(
             `https://api.thecatapi.com/v1/favourites/${favoriteId}`,
-            { headers: { 'x-api-key': CAT_API_KEY } },
+            { headers: { 'x-api-key': secret_key } },
           );
           setFavorites((prev) => {
             const updated = { ...prev };
@@ -53,7 +54,7 @@ export const useFavorites = (
             { image_id: imageId },
             {
               headers: {
-                'x-api-key': CAT_API_KEY,
+                'x-api-key': secret_key,
                 'Content-Type': 'application/json',
               },
             },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-image-picker": "^7.1.2",
     "react-native-reanimated": "~3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,7 +3957,7 @@ dotenv-expand@~11.0.6:
   dependencies:
     dotenv "^16.4.4"
 
-dotenv@^16.4.4, dotenv@^16.4.5, dotenv@~16.4.5:
+dotenv@^16.4.4, dotenv@~16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
@@ -8083,13 +8083,6 @@ react-native-css-interop@0.1.22:
     debug "^4.3.7"
     lightningcss "^1.27.0"
     semver "^7.6.3"
-
-react-native-dotenv@^3.4.11:
-  version "3.4.11"
-  resolved "https://registry.yarnpkg.com/react-native-dotenv/-/react-native-dotenv-3.4.11.tgz#2e6c4eabd55d5f1bf109b3dd9141dadf9c55cdd4"
-  integrity sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==
-  dependencies:
-    dotenv "^16.4.5"
 
 react-native-gesture-handler@~2.16.1:
   version "2.16.2"


### PR DESCRIPTION
## Description

This update addresses the issue regarding the use of the react-native-dotenv Babel plugin in the project. Currently, this plugin conflicts with Expo Router's environment variable configuration, resulting in the empty state "Welcome to Expo" screen. The issue is being tracked in [expo/expo#28933](https://github.com/expo/expo/issues/28933).

I have removed the dotenv plugin and I am now using Expo CLI's built-in support for .env files [learn more](https://docs.expo.dev/guides/environment-variables/).